### PR TITLE
Made foreground color of status bar more readable while debugging

### DIFF
--- a/themes/slime-theme.json
+++ b/themes/slime-theme.json
@@ -42,6 +42,7 @@
 		"statusBar.background": "#282e2f",
 		"statusBar.debuggingBackground": "#cd6564",
 		"statusBar.foreground": "#939d9f",
+		"statusBar.debuggingForeground": "#E2E2E2",
 		"statusBar.noFolderBackground": "#343b3c",
 		"tab.activeBackground": "#24292a",
 		"tab.border": "#343b3c",


### PR DESCRIPTION
Fixes #2 

Before:
![image](https://user-images.githubusercontent.com/9491603/30822462-23d492fc-a229-11e7-8877-c94e8f9d60b2.png)

After:
![image](https://user-images.githubusercontent.com/9491603/30822449-1721708e-a229-11e7-8325-7170f572bcf0.png)
